### PR TITLE
Add enabled_taint option to schedule pod on master

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -20,6 +20,7 @@
 - hosts: kube-master
   roles:
     - nvidia
+    - { role: k8s-setting/taint, when: taint_enabled == 'true', tags: taint }
 
 - import_playbook: glusterfs.yml
   when: enable_glusterfs

--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -239,3 +239,7 @@ persistent_volumes_enabled: false
 ## See https://github.com/kubernetes-incubator/kubespray/issues/2141
 ## Set this variable to true to get rid of this issue
 volume_cross_zone_attachment: false
+
+# Enable to schedule pods on the master
+# For `kubectl taint nodes --all node-role.kubernetes.io/master-`
+taint_enabled: true

--- a/roles/k8s-setting/taint/tasks/main.yml
+++ b/roles/k8s-setting/taint/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: Enable to schedule pods on the master(taint)
+  shell: kubectl taint nodes --all node-role.kubernetes.io/master-
+  when: taint_enabled == 'true'


### PR DESCRIPTION
After enabled_taint is true in inventory/group_vars/k8s-cluster.yml, we
enable to schedule pods on the master. The `kubectl` command will be ran
after k8s cluster finish.