### PR TITLE
Fix modules load at boot time & reset it

### DIFF
--- a/roles/network-setup/dpdk/tasks/setting-kmod.yml
+++ b/roles/network-setup/dpdk/tasks/setting-kmod.yml
@@ -19,7 +19,7 @@
 
 # Make uio and igb_uio installations persist across reboots
 - name: Insert igb_uio when kernal_module is UIO
-  command: "{{ item }}"
+  shell: "{{ item }}"
   with_items:
     - ln -sf {{ DPDK_DIR }}/x86_64-native-linuxapp-gcc/kmod/igb_uio.ko /lib/modules/{{ kernel_version_output.stdout }}
     - depmod -a

--- a/roles/network-setup/reset/tasks/dpdk.yml
+++ b/roles/network-setup/reset/tasks/dpdk.yml
@@ -79,3 +79,5 @@
     - sed -i '/DPDK_BUILD/d' ~/.bashrc
     - sed -i '/IFDRV_/d' ~/.bashrc
     - sed -i '/IFnum_/d' ~/.bashrc
+    - sed -i '/uio/d' /etc/modules
+    - sed -i '/igb_uio/d' /etc/modules


### PR DESCRIPTION
因為我們要用到 `|` 所以要改用 shell
https://www.jianshu.com/p/081139f73613

After reboot
```
$ lsmod | grep uio
igb_uio                16384  0
uio                    20480  1 igb_uio
```

重啟後，module 會被 load 進來
但還是要綁定 device  到 igb_uio 可能要寫進 `/etc/rc.local`?