### PR TITLE
Add env check after network setting finished

### DIFF
--- a/network-setup.yml
+++ b/network-setup.yml
@@ -7,6 +7,7 @@
     - { role: network-setup/dpdk, when: kernel_module == 'igb_uio' or ovs_type == 'dpdk', tags: dpdk }
     - { role: network-setup/dpdk-ovs, when: ovs_type == 'dpdk', tags: dpdk-ovs }
     - { role: network-setup/setup-dpdk-ovs, when: ovs_type == 'dpdk', tags: dpdk-ovs }
+    - { role: network-setup/check-all, when: ovs_type == 'dpdk', tags: dpdk-ovs }
 
 
 # The inventory.sample is

--- a/roles/network-setup/check-all/tasks/main.yml
+++ b/roles/network-setup/check-all/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+
+- name: Info | Get OS info
+  shell: cat /etc/lsb-release
+  register: os_result
+
+- name: Info | Print OS info
+  debug:
+    msg: "{{ os_result.stdout.split('\n') }}"
+
+- name: Info | Get Kernel info
+  shell: uname -msr
+  register: kernel_result
+
+- name: Info | Print kernel info
+  debug:
+    msg: "{{ kernel_result.stdout }}"
+
+- name: Info | Get Hugepage info
+  shell: cat /proc/meminfo | grep Huge
+  register: hp_result
+
+- name: Info | Print Hugepage info
+  debug:
+    msg: "{{ hp_result.stdout.split('\n') }}"
+
+- name: Info | Get CPU info
+  shell: cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+  register: cpu_result
+
+- name: Info | Print cpu info
+  debug:
+    msg: "{{ cpu_result.stdout.split('\n') }}"
+
+- name: DPDK | Get dpdk info
+  shell: cd /usr/src/dpdk-stable-{{ dpdk_version }} && pwd
+  register: dpdk_result
+
+- name: DPDK | Print dpdk info
+  debug:
+    msg: "{{ dpdk_result.stdout }}"
+
+- name: OVS | Get ovs info
+  shell: sudo ovs-vsctl show
+  register: ovs_result
+
+- name: OVS | Print ovs info
+  debug:
+    msg: "{{ ovs_result.stdout.split('\n') }}"
+
+- name: OVS | Get ovsdb-server.service info
+  shell: systemctl status ovsdb-server.service --no-pager
+  register: ovsdb_result
+
+- name: OVS | Print ovsdb-server.service info
+  debug:
+    msg: "{{ ovsdb_result.stdout.split('\n') }}"
+
+- name: OVS | Get ovs-vswitchd.service info
+  shell: systemctl status ovs-vswitchd.service --no-pager
+  register: vswitchd_result
+
+- name: OVS | Print ovs-vswitchd.service info
+  debug:
+    msg: "{{ vswitchd_result.stdout.split('\n') }}"


### PR DESCRIPTION
```
TASK [network-setup/check-all : Info | Get OS info] **********************************************************************************************************
changed: [node-2]
changed: [node-1]

TASK [network-setup/check-all : Info | Print OS info] ********************************************************************************************************
ok: [node-1] => {
    "msg": [
        "DISTRIB_ID=Ubuntu",
        "DISTRIB_RELEASE=16.04",
        "DISTRIB_CODENAME=xenial",
        "DISTRIB_DESCRIPTION=\"Ubuntu 16.04.5 LTS\""
    ]
}
ok: [node-2] => {
    "msg": [
        "DISTRIB_ID=Ubuntu",
        "DISTRIB_RELEASE=16.04",
        "DISTRIB_CODENAME=xenial",
        "DISTRIB_DESCRIPTION=\"Ubuntu 16.04.5 LTS\""
    ]
}

TASK [network-setup/check-all : Info | Get Kernel info] ******************************************************************************************************
changed: [node-1]
changed: [node-2]

TASK [network-setup/check-all : Info | Print kernel info] ****************************************************************************************************
ok: [node-1] => {
    "msg": "Linux 4.15.0-34-generic x86_64"
}
ok: [node-2] => {
    "msg": "Linux 4.15.0-34-generic x86_64"
}

TASK [network-setup/check-all : Info | Get Hugepage info] ****************************************************************************************************
changed: [node-1]
changed: [node-2]

TASK [network-setup/check-all : Info | Print Hugepage info] **************************************************************************************************
ok: [node-1] => {
    "msg": [
        "AnonHugePages:         0 kB",
        "ShmemHugePages:        0 kB",
        "HugePages_Total:       8",
        "HugePages_Free:        7",
        "HugePages_Rsvd:        0",
        "HugePages_Surp:        0",
        "Hugepagesize:    1048576 kB"
    ]
}
ok: [node-2] => {
    "msg": [
        "AnonHugePages:         0 kB",
        "ShmemHugePages:        0 kB",
        "HugePages_Total:       8",
        "HugePages_Free:        7",
        "HugePages_Rsvd:        0",
        "HugePages_Surp:        0",
        "Hugepagesize:    1048576 kB"
    ]
}

TASK [network-setup/check-all : Info | Get CPU info] *********************************************************************************************************
changed: [node-1]
changed: [node-2]

TASK [network-setup/check-all : Info | Print cpu info] *******************************************************************************************************
ok: [node-1] => {
    "msg": [
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance"
    ]
}
ok: [node-2] => {
    "msg": [
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance",
        "performance"
    ]
}

TASK [network-setup/check-all : DPDK | Get dpdk info] ********************************************************************************************************
changed: [node-1]
changed: [node-2]

TASK [network-setup/check-all : DPDK | Print dpdk info] ******************************************************************************************************
ok: [node-1] => {
    "msg": "/usr/src/dpdk-stable-17.11.4"
}
ok: [node-2] => {
    "msg": "/usr/src/dpdk-stable-17.11.4"
}

TASK [network-setup/check-all : OVS | Get ovs info] **********************************************************************************************************
 [WARNING]: Consider using 'become', 'become_method', and 'become_user' rather than running sudo

changed: [node-1]
changed: [node-2]

TASK [network-setup/check-all : OVS | Print ovs info] ********************************************************************************************************
ok: [node-1] => {
    "msg": [
        "93dece1d-8974-4c86-8c5b-0a222c87e505",
        "    Bridge \"system-ac2575\"",
        "        Port \"ens1f1\"",
        "            Interface \"ens1f1\"",
        "        Port \"system-ac2575\"",
        "            Interface \"system-ac2575\"",
        "                type: internal",
        "        Port \"ens1f0\"",
        "            Interface \"ens1f0\"",
        "    ovs_version: \"2.9.2\""
    ]
}
ok: [node-2] => {
    "msg": [
        "1cbc1c9d-8698-4ab4-9f4c-34f04a3d75a0",
        "    Bridge \"system-ac2575\"",
        "        Port \"ens1f1\"",
        "            Interface \"ens1f1\"",
        "        Port \"vtxfa1d5a13b\"",
        "            Interface \"vtxfa1d5a13b\"",
        "        Port \"system-ac2575\"",
        "            Interface \"system-ac2575\"",
        "                type: internal",
        "        Port \"vtxc4dd2440d\"",
        "            Interface \"vtxc4dd2440d\"",
        "        Port \"ens1f0\"",
        "            Interface \"ens1f0\"",
        "    ovs_version: \"2.9.2\""
    ]
}

TASK [network-setup/check-all : OVS | Get ovsdb-server.service info] *****************************************************************************************
changed: [node-1]
changed: [node-2]

TASK [network-setup/check-all : OVS | Print ovsdb-server.service info] ***************************************************************************************
ok: [node-1] => {
    "msg": [
        "● ovsdb-server.service - Open vSwitch Database Unit",
        "   Loaded: loaded (/etc/systemd/system/ovsdb-server.service; enabled; vendor preset: enabled)",
        "   Active: active (running) since 三 2018-09-19 16:41:49 CST; 1 weeks 4 days ago",
        "    Tasks: 1",
        "   Memory: 3.4M",
        "      CPU: 55.590s",
        "   CGroup: /system.slice/ovsdb-server.service",
        "           └─26560 ovsdb-server /etc/openvswitch/conf.db -vconsole:emer -vsyslog:err -vfile:info --remote=punix:/var/run/openvswitch/db.sock --private-key=db:Open_vSwitch,SSL,private_key --certificate=db:Open_vSwitch,SSL,certificate --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert --no-chdir --log-file=/var/log/openvswitch/ovsdb-server.log --pidfile=/var/run/openvswitch/ovsdb-server.pid --detach",
...
```