### PR TITLE
Add fuction for prevent upgrade kernel version

### DIFF
--- a/roles/network-setup/check-all/tasks/main.yml
+++ b/roles/network-setup/check-all/tasks/main.yml
@@ -16,6 +16,14 @@
   debug:
     msg: "{{ kernel_result.stdout }}"
 
+- name: Info | Get showhold
+  shell: sudo apt-mark showhold
+  register: show_hold
+
+- name: Info | Print showhold
+  debug:
+    msg: "{{ show_hold.stdout.split('\n') }}"
+
 - name: Info | Get Hugepage info
   shell: cat /proc/meminfo | grep Huge
   register: hp_result

--- a/roles/network-setup/dpdk/tasks/dpdk.yml
+++ b/roles/network-setup/dpdk/tasks/dpdk.yml
@@ -32,6 +32,9 @@
     - htop
   when: ansible_os_family == 'Debian' or ovs_type == 'dpdk'
 
+- name: Mark linux kernel as held back, prevent kernel version from being automatically installed, upgraded or removed.
+  shell: sudo apt-mark hold {{ kernel_version_output.stdout }}
+
 # Download DPDK source
 - name: download DPDK source
   get_url:

--- a/roles/network-setup/reset/tasks/ovs.yml
+++ b/roles/network-setup/reset/tasks/ovs.yml
@@ -33,3 +33,6 @@
 - name: Uninstall public OVS
   shell: apt-get remove --auto-remove openvswitch-switch --purge
   when: ovs_type == 'ovs'
+
+- name: Unmark linux kernel as held back, let kernel version can being automatically installed, upgraded or removed.
+  shell: sudo apt-mark unhold {{ kernel_version_output.stdout }}


### PR DESCRIPTION
```
$ sudo apt-mark hold 4.15.0-34-generic
linux-cloud-tools-4.15.0-34-generic set on hold.
linux-headers-4.15.0-34-generic set on hold.
linux-image-4.15.0-34-generic set on hold.
linux-modules-4.15.0-34-generic set on hold.
linux-image-unsigned-4.15.0-34-generic set on hold.
linux-modules-extra-4.15.0-34-generic set on hold.
linux-tools-4.15.0-34-generic set on hold.

$ sudo apt-mark showhold
linux-cloud-tools-4.15.0-34-generic
linux-headers-4.15.0-34-generic
linux-image-4.15.0-34-generic
linux-image-unsigned-4.15.0-34-generic
linux-modules-4.15.0-34-generic
linux-modules-extra-4.15.0-34-generic
linux-tools-4.15.0-34-generic
```
Ref: http://manpages.ubuntu.com/manpages/xenial/man8/apt-mark.8.html