### PR TITLE
Fix reset network for apt-mark unhold kernel_version

### DIFF
--- a/roles/network-setup/reset/tasks/ovs.yml
+++ b/roles/network-setup/reset/tasks/ovs.yml
@@ -34,5 +34,9 @@
   shell: apt-get remove --auto-remove openvswitch-switch --purge
   when: ovs_type == 'ovs'
 
+- name: Get Kernel version
+  shell: uname -r
+  register: kernel_version_output
+
 - name: Unmark linux kernel as held back, let kernel version can being automatically installed, upgraded or removed.
   shell: sudo apt-mark unhold {{ kernel_version_output.stdout }}


### PR DESCRIPTION
忘記 reset 的時候先要 kernel version 的資訊
導致 apt-mark unhold 沒有拿到 kernel version 的資料

所以補加